### PR TITLE
Fixed misleading error message for Mac OS X

### DIFF
--- a/src/scripts/macosx.lua
+++ b/src/scripts/macosx.lua
@@ -14,7 +14,7 @@ local s = {}
 local function validate(project)
   local valid, err = true, utils.io.err
   if type(project.identifier) ~= "string" or project.identifier == "" then
-    err("DEBIAN: No author specified.\n")
+    err("MacOS X: No identifier specified.\n")
     valid = false
   end
   if not valid then os.exit(1) end


### PR DESCRIPTION
When the identifier is missing it would prompt an error message
which would tell that the author is missing.