### PR TITLE
Debian: Allows special characters in title

### DIFF
--- a/src/scripts/debian.lua
+++ b/src/scripts/debian.lua
@@ -106,7 +106,7 @@ function s.script(project)
   -- /usr/bin/${PACKAGE}
   writeFile("/usr/bin/"..project.package,
       "#!/bin/sh\n"..
-      "love "..loveFileDeb.."\n",
+      "love '"..loveFileDeb:gsub("'", "\\'").."'\n",
       true
   )
   assert(fs.chmod(tempDir.."/usr/bin/"..project.package, "+x"))


### PR DESCRIPTION
When using spaces (or other) in `title`, the executable in `/usr/bin` would not load the file and show the default "no game" screen.

It stills fail when using spaces (or other) in `package`, but it fails at packaging time so it's less of a concern.