### PR TITLE
Fixed bug where empty exclude arguments would override value from conf.lua

### DIFF
--- a/src/pipes/args.lua
+++ b/src/pipes/args.lua
@@ -91,7 +91,7 @@ function Args:__call(project)
   if args.url then project:setHomepage(args.url) end
   if args.uti then project:setIdentifier(args.uti) end
   if args.version then project:setVersion(args.version) end
-  if args.excludeFileList then project:setExcludeFileList(args.excludeFileList) end
+  if #args.excludeFileList >= 1 then project:setExcludeFileList(args.excludeFileList) end
 
   if project.projectDirectory == project.releaseDirectory then
     project:setReleaseDirectory(project.releaseDirectory.."/releases")


### PR DESCRIPTION
I guess this broke at some point, every time I run love-release the values I've set inside my `conf.lua` are overwritten with an empty table.