### PR TITLE
Bashful attempt to satisfy travis.

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -41,8 +41,10 @@ function ver:new(str)
    local major, minor, patch = str:match("^(%d+)%.?(%d*)%.?(%d*)$")
    assert(type(major) == 'string',
           ("Could not extract version number(s) from %q"):format(str))
-   local major, minor, patch = tonumber(major), tonumber(minor), tonumber(patch)
-   local o = { major = major, minor = minor, patch = patch, str = str }
+   local o = { major = tonumber(major),
+               minor = tonumber(minor),
+               patch = tonumber(patch),
+               str = str }
    setmetatable(o, self)
    self.__index = self
    return o


### PR DESCRIPTION
Just one of thousands ways to get rid of travis warnings.
```
src/utils.lua:44:10: variable major was previously defined on line 41
src/utils.lua:44:17: variable minor was previously defined on line 41
src/utils.lua:44:24: variable patch was previously defined on line 41
```