### PR TITLE
Also delete lovec.exe from Windows archive

### DIFF
--- a/src/scripts/windows.lua
+++ b/src/scripts/windows.lua
@@ -64,6 +64,7 @@ local function release(script, project, arch)
 
   ar:add(dir..project.package..".exe", "string", exe..game)
   ar:delete(dir.."love.exe")
+  ar:delete(dir.."lovec.exe")
   ar:delete(dir.."readme.txt")
   ar:delete(dir.."changes.txt")
 


### PR DESCRIPTION
Hello.
Since you're deleting love.exe from Windows archive, I think also deleting lovec.exe is sensible thing, so that end users are not confused on which executable they should run.