### PR TITLE
Fix windows release directory renaming, regex string escaping and indentation

### DIFF
--- a/src/pipes/args.lua
+++ b/src/pipes/args.lua
@@ -17,9 +17,9 @@ function Args:initialize()
   self.pre = Args.pre
 
   local parser = argparse()
-      :name "love-release"
-      :description "Makes LÖVE games releases easier !"
-      :epilog "For more info, see https://github.com/MisterDA/love-release"
+    :name "love-release"
+    :description "Makes LÖVE games releases easier !"
+    :epilog "For more info, see https://github.com/MisterDA/love-release"
 
 
   parser:argument("release", "Project release directory.")

--- a/src/pipes/conf.lua
+++ b/src/pipes/conf.lua
@@ -39,8 +39,8 @@ function pipe.pipe(project)
       if not utils.love.isSupported(version) then
         local scriptLoveVersion = project.loveVersion
         err("CONF: Your LÖVE conf version ("..v
-         .. ") is not supported by love-release ("..tostring(scriptLoveVersion)
-         .. ").\n")
+              .. ") is not supported by love-release ("..tostring(scriptLoveVersion)
+              .. ").\n")
         if version > scriptLoveVersion then
           err("      You should update love-release.\n")
         elseif version < scriptLoveVersion then
@@ -76,8 +76,6 @@ function pipe.pipe(project)
 end
 
 
-setmetatable(pipe, {
-  __call = function(_, project) return pipe.pipe(project) end,
-})
+setmetatable(pipe, { __call = function(_, project) return pipe.pipe(project) end })
 
 return pipe

--- a/src/pipes/env.lua
+++ b/src/pipes/env.lua
@@ -84,8 +84,8 @@ function pipe.pipe(project)
 
   if systemLoveVersion and not isSupported(systemLoveVersion) then
     err("ENV: Your LÖVE installed version (" .. tostring(systemLoveVersion) ..
-        ") is not supported by love-release (" .. tostring(scriptLoveVersion) ..
-        ").\n")
+          ") is not supported by love-release (" .. tostring(scriptLoveVersion) ..
+          ").\n")
     if systemLoveVersion > scriptLoveVersion then
       err("     You should update love-release.\n")
     elseif systemLoveVersion < scriptLoveVersion then
@@ -95,8 +95,8 @@ function pipe.pipe(project)
 
   if webLoveVersion and not isSupported(webLoveVersion) then
     err("ENV: The upstream LÖVE version (" .. tostring(webLoveVersion) ..
-        ") is not supported by love-release (" .. tostring(scriptLoveVersion) ..
-        ").\n")
+          ") is not supported by love-release (" .. tostring(scriptLoveVersion) ..
+          ").\n")
     err("     You should update love-release.\n")
   end
 
@@ -108,8 +108,6 @@ function pipe.pipe(project)
 end
 
 
-setmetatable(pipe, {
-  __call = function(_, project) return pipe.pipe(project) end,
-})
+setmetatable(pipe, { __call = function(_, project) return pipe.pipe(project) end })
 
 return pipe

--- a/src/project.lua
+++ b/src/project.lua
@@ -142,8 +142,8 @@ end
 -- it is within the project directory.
 function Project:excludeFiles()
   local dir, rm_dir = self.releaseDirectory:gsub(
-      "^"..utils.lua.escape_string_regex(self.projectDirectory).."/",
-      "")
+    "^"..utils.lua.escape_string_regex(self.projectDirectory).."/",
+    "")
   if rm_dir > 0 then
     dir = "^"..dir
   end
@@ -184,21 +184,21 @@ end
 -- @local
 function Project:__tostring()
   return
-  '{\n'..
-  '  title = '..escape(self.title)..',\n'..
-  '  package = '..escape(self.package)..',\n'..
-  '  loveVersion = \''..escape(self.loveVersion)..'\',\n'..
-  '  version = '..escape(self.version)..',\n'..
-  '  author = '..escape(self.author)..',\n'..
-  '  email = '..escape(self.email)..',\n'..
-  '  description = '..escape(self.description)..',\n'..
-  '  homepage = '..escape(self.homepage)..',\n'..
-  '  identifier = '..escape(self.identifier)..',\n'..
-  '  excludeFileList = { '..escape(table.concat(self.excludeFileList, "', '"))..'} ,\n'..
-  '  compile = '..escape(self.compile)..',\n'..
-  '  projectDirectory = '..escape(self.projectDirectory)..',\n'..
-  '  releaseDirectory = '..escape(self.releaseDirectory)..',\n'..
-  '}'
+    '{\n'..
+    '  title = '..escape(self.title)..',\n'..
+    '  package = '..escape(self.package)..',\n'..
+    '  loveVersion = \''..escape(self.loveVersion)..'\',\n'..
+    '  version = '..escape(self.version)..',\n'..
+    '  author = '..escape(self.author)..',\n'..
+    '  email = '..escape(self.email)..',\n'..
+    '  description = '..escape(self.description)..',\n'..
+    '  homepage = '..escape(self.homepage)..',\n'..
+    '  identifier = '..escape(self.identifier)..',\n'..
+    '  excludeFileList = { '..escape(table.concat(self.excludeFileList, "', '"))..'} ,\n'..
+    '  compile = '..escape(self.compile)..',\n'..
+    '  projectDirectory = '..escape(self.projectDirectory)..',\n'..
+    '  releaseDirectory = '..escape(self.releaseDirectory)..',\n'..
+    '}'
 end
 
 --- Sets the title.

--- a/src/scripts/debian.lua
+++ b/src/scripts/debian.lua
@@ -80,34 +80,34 @@ function s.script(project)
 
   -- /DEBIAN/control
   writeFile("/DEBIAN/control",
-      "Package: "..project.package.."\n"..
-      "Version: "..project.version.."\n"..
-      "Architecture: all\n"..
-      "Maintainer: "..project.author.." <"..project.email..">\n"..
-      "Installed-Size: "..
-        math.floor(assert(lfs.attributes(loveFileRel, "size")) / 1024).."\n"..
-      "Depends: love (>= "..tostring(project.loveVersion)..")\n"..
-      "Priority: extra\n"..
-      "Homepage: "..project.homepage.."\n"..
-      "Description: "..project.description.."\n"
+            "Package: "..project.package.."\n"..
+              "Version: "..project.version.."\n"..
+              "Architecture: all\n"..
+              "Maintainer: "..project.author.." <"..project.email..">\n"..
+              "Installed-Size: "..
+              math.floor(assert(lfs.attributes(loveFileRel, "size")) / 1024).."\n"..
+              "Depends: love (>= "..tostring(project.loveVersion)..")\n"..
+              "Priority: extra\n"..
+              "Homepage: "..project.homepage.."\n"..
+              "Description: "..project.description.."\n"
   )
 
   -- /usr/share/applications/${PACKAGE}.desktop
   writeFile("/usr/share/applications/"..project.package..".desktop",
-      "[Desktop Entry]\n"..
-      "Name="..project.title.."\n"..
-      "Comment="..project.description.."\n"..
-      "Exec="..project.package.."\n"..
-      "Type=Application\n"..
-      "Categories=Game;\n",
-      true
+            "[Desktop Entry]\n"..
+              "Name="..project.title.."\n"..
+              "Comment="..project.description.."\n"..
+              "Exec="..project.package.."\n"..
+              "Type=Application\n"..
+              "Categories=Game;\n",
+            true
   )
 
   -- /usr/bin/${PACKAGE}
   writeFile("/usr/bin/"..project.package,
-      "#!/bin/sh\n"..
-      "love '"..loveFileDeb:gsub("'", "\\'").."'\n",
-      true
+            "#!/bin/sh\n"..
+              "love '"..loveFileDeb:gsub("'", "\\'").."'\n",
+            true
   )
   -- FIXME: escape this path?
   assert(fs.set_permissions(tempDir.."/usr/bin/"..project.package,
@@ -125,7 +125,7 @@ function s.script(project)
 
   -- create the package
   local deb = project.releaseDirectory.."/"..project.package.."-"..
-              project.version.."_all.deb"
+    project.version.."_all.deb"
   fs.delete(deb)
   assert(fs.execute("fakeroot dpkg-deb -b ", tempDir, deb),
          "DEBIAN: error while building the package.")
@@ -134,8 +134,6 @@ function s.script(project)
 end
 
 
-setmetatable(s, {
-  __call = function(_, project) return s.script(project) end,
-})
+setmetatable(s, { __call = function(_, project) return s.script(project) end })
 
 return s

--- a/src/scripts/love.lua
+++ b/src/scripts/love.lua
@@ -13,8 +13,6 @@ function s.script(project)
 end
 
 
-setmetatable(s, {
-  __call = function(_, project) return s.script(project) end,
-})
+setmetatable(s, { __call = function(_, project) return s.script(project) end })
 
 return s

--- a/src/scripts/macos.lua
+++ b/src/scripts/macos.lua
@@ -62,12 +62,12 @@ function s.script(project)
   local infoPlist = assert(infoPlistHandle:read(infoPlistSize))
   infoPlistHandle:close()
   infoPlist = infoPlist
-      :gsub("\n\t<key>UTExportedTypeDeclarations</key>.*</array>",
-            "")
-      :gsub("(CFBundleIdentifier.-<string>)(.-)(</string>)",
-         "%1"..project.identifier.."%3")
-      :gsub("(CFBundleName.-<string>)(.-)(</string>)",
-            "%1"..project.title..".love%3")
+    :gsub("\n\t<key>UTExportedTypeDeclarations</key>.*</array>",
+          "")
+    :gsub("(CFBundleIdentifier.-<string>)(.-)(</string>)",
+          "%1"..project.identifier.."%3")
+    :gsub("(CFBundleName.-<string>)(.-)(</string>)",
+          "%1"..project.title..".love%3")
 
   ar:add("love.app/Contents/Resources/"..script.loveFile,
          "file", script.loveFile)
@@ -91,8 +91,6 @@ function s.script(project)
 end
 
 
-setmetatable(s, {
-  __call = function(_, project) return s.script(project) end,
-})
+setmetatable(s, { __call = function(_, project) return s.script(project) end })
 
 return s

--- a/src/scripts/windows.lua
+++ b/src/scripts/windows.lua
@@ -74,7 +74,7 @@ local function release(script, project, arch)
     if stat then
       ar:rename(i, stat.name:gsub(
                   "^"..utils.lua.escape_string_regex(dir),
-                  utils.lua.escape_string_regex(project.title).."-win"..arch.."/"))
+                  project.title.."-win"..arch.."/"))
     end
   end
 

--- a/src/scripts/windows.lua
+++ b/src/scripts/windows.lua
@@ -14,7 +14,7 @@ local s = {}
 local function release(script, project, arch)
   local prefix, dir, bin
   if project.loveVersion == ver'11.2' or
-     project.loveVersion == ver'11.1' then
+  project.loveVersion == ver'11.1' then
     prefix = "love-"..tostring(project.loveVersion)
     dir = prefix..".0-win"..arch.."/"
     prefix = prefix.."-win"
@@ -73,8 +73,8 @@ local function release(script, project, arch)
     stat = ar:stat(i)
     if stat then
       ar:rename(i, stat.name:gsub(
-          "^"..utils.lua.escape_string_regex(dir),
-          utils.lua.escape_string_regex(project.title).."-win"..arch.."/"))
+                  "^"..utils.lua.escape_string_regex(dir),
+                  utils.lua.escape_string_regex(project.title).."-win"..arch.."/"))
     end
   end
 
@@ -97,8 +97,6 @@ function s.script(project, arch)
 end
 
 
-setmetatable(s, {
-  __call = function(_, project, arch) return s.script(project, arch) end,
-})
+setmetatable(s, { __call = function(_, project, arch) return s.script(project, arch) end })
 
 return s

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -128,11 +128,13 @@ end
 --- Escapes a string to use as a regex.
 -- @string string to escape.
 function utils.lua.escape_string_regex(string)
-  -- ^$()%.[]*+-?
-  return string:gsub('%%', '%%%%'):gsub('^%^', '%%^'):gsub('%$$', '%%$')
-    :gsub('%(', '%%('):gsub('%)', '%%)'):gsub('%.', '%%.')
-    :gsub('%[', '%%['):gsub('%]', '%%]'):gsub('%*', '%%*')
-    :gsub('%+', '%%+'):gsub('%-', '%%-'):gsub('%?', '%%?')
+  return string:gsub('[%^%$%(%)%%%.%[%]%*%+%-%?%z]', {
+                       ['^'] = '%^'; ['$'] = '%$'; ['('] = '%(';
+                       [')'] = '%)'; ['%'] = '%%'; ['.'] = '%.';
+                       ['['] = '%['; [']'] = '%]'; ['*'] = '%*';
+                       ['+'] = '%+'; ['-'] = '%-'; ['?'] = '%?';
+                       ['\0'] = '%z';
+  })
 end
 
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -16,9 +16,9 @@ fs.init()
 utils.cache = nil
 
 do
-   local cache = dir.dir_name(cfg.local_cache) .. "/love-release"
-   assert(fs.make_dir(cache))
-   utils.cache = cache
+  local cache = dir.dir_name(cfg.local_cache) .. "/love-release"
+  assert(fs.make_dir(cache))
+  utils.cache = cache
 end
 
 
@@ -27,42 +27,42 @@ end
 utils.love = {}
 
 local ver = {
-   major = nil,
-   minor = nil,
-   patch = nil,
-   str = nil
+  major = nil,
+  minor = nil,
+  patch = nil,
+  str = nil
 }
 utils.love.ver = ver
 
 function ver:new(str)
-   local major, minor, patch = str:match("^(%d+)%.?(%d*)%.?(%d*)$")
-   assert(type(major) == 'string',
-          ("Could not extract version number(s) from %q"):format(str))
-   local o = { major = tonumber(major),
-               minor = tonumber(minor),
-               patch = tonumber(patch),
-               str = str }
-   setmetatable(o, self)
-   self.__index = self
-   return o
+  local major, minor, patch = str:match("^(%d+)%.?(%d*)%.?(%d*)$")
+  assert(type(major) == 'string',
+         ("Could not extract version number(s) from %q"):format(str))
+  local o = { major = tonumber(major),
+              minor = tonumber(minor),
+              patch = tonumber(patch),
+              str = str }
+  setmetatable(o, self)
+  self.__index = self
+  return o
 end
 
 function ver:__eq(other)
-   return self.major == other.major and self.minor == other.minor and
-      self.patch == other.patch
+  return self.major == other.major and self.minor == other.minor and
+    self.patch == other.patch
 end
 
 function ver:__lt(other)
-   if self.major ~= other.major then return self.major < other.major end
-   if self.minor ~= other.minor then return self.minor < other.minor end
-   if self.patch ~= other.patch then return self.patch < other.patch end
-   return false
+  if self.major ~= other.major then return self.major < other.major end
+  if self.minor ~= other.minor then return self.minor < other.minor end
+  if self.patch ~= other.patch then return self.patch < other.patch end
+  return false
 end
 
 function ver:__tostring()
-   local buffer = { ("%d.%d"):format(self.major, self.minor) }
-   if self.patch then table.insert(buffer, "." .. self.patch) end
-   return table.concat(buffer)
+  local buffer = { ("%d.%d"):format(self.major, self.minor) }
+  if self.patch then table.insert(buffer, "." .. self.patch) end
+  return table.concat(buffer)
 end
 
 setmetatable(ver, { __call = ver.new })
@@ -97,7 +97,7 @@ utils.love.minVersion = utils.love.versionTable[#utils.love.versionTable]
 function utils.love.isSupported(version)
   assert(getmetatable(version) == ver)
   if version >= utils.love.minVersion
-      and version <= utils.love.lastVersion then
+  and version <= utils.love.lastVersion then
     for _, v in ipairs(utils.love.versionTable) do
       if version == v then
         return true
@@ -130,9 +130,9 @@ end
 function utils.lua.escape_string_regex(string)
   -- ^$()%.[]*+-?
   return string:gsub('%%', '%%%%'):gsub('^%^', '%%^'):gsub('%$$', '%%$')
-                :gsub('%(', '%%('):gsub('%)', '%%)'):gsub('%.', '%%.')
-                :gsub('%[', '%%['):gsub('%]', '%%]'):gsub('%*', '%%*')
-                :gsub('%+', '%%+'):gsub('%-', '%%-'):gsub('%?', '%%?')
+    :gsub('%(', '%%('):gsub('%)', '%%)'):gsub('%.', '%%.')
+    :gsub('%[', '%%['):gsub('%]', '%%]'):gsub('%*', '%%*')
+    :gsub('%+', '%%+'):gsub('%-', '%%-'):gsub('%?', '%%?')
 end
 
 


### PR DESCRIPTION
**1**. Fixed bug caused by the use of `%` on replacement string when calling `string.gsub` (**lua**>=5.2). According to lua-users: ([**link**](http://lua-users.org/wiki/LuaFiveTwo))
> ### string.gsub repl
> string.gsub [[6]](http://www.lua.org/manual/5.2/manual.html#pdf-string.gsub) now raises an error if the replacement string contains a '%' followed by a character other than the permitted '%' or digit.

In short, the replacement string does not require escaping of *magic characters*.

**2**. Function `utils.lua.escape_string_regex` recreated with single `string.gsub` call.

**3**. Converted a few lines of code with three spaces of indentation to two.